### PR TITLE
Add event name to push_message

### DIFF
--- a/shampoo/schemas/push_message.json
+++ b/shampoo/schemas/push_message.json
@@ -5,10 +5,14 @@
     "type": "object",
 
     "properties": {
+        "push_event": {
+            "description": "Name of the push event",
+            "type": "string"
+        },
         "push_data": {
             "description": "Response data from the called method",
             "type": "object"
         }
     },
-    "required": ["push_data"]
+    "required": ["push_event", "push_data"]
 }


### PR DESCRIPTION
This proposes to add a required "event name". I'm not married to that name, seeing as `push_type` and `push_title` and `push_message` or just `message` might be better.
